### PR TITLE
fix: send interrupt only when server vad not enabled or forced

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -868,7 +868,9 @@ class AgentActivity(RecognitionHooks):
             speech.interrupt(force=force)
             interrupted_speeches.append(speech)
 
-        if self._rt_session is not None:
+        if self._rt_session is not None and (
+            not self._rt_session.realtime_model.capabilities.turn_detection or force
+        ):
             self._rt_session.interrupt()
 
         if not interrupted_speeches:


### PR DESCRIPTION
## Description

When we're using a Realtime Model with server side VAD, the server is responsible of generating `input_speech_started` events. In that cases, we don't want to send a `cancel` event to the model as we would be self interrupting ourselves.

Example of current flow:
- We receive an `input_speech_started` event ([see handle](https://github.com/livekit/agents/blob/06f5321bba0eb90863396df72eb4972d70ebf86a/livekit-agents/livekit/agents/voice/agent_activity.py#L1013-L1024))
- Since we use server interruption, we allow_interruptions can't be false
- Then in `interrupt` we would be sending an interruption to the server (from the server's own event)

Appreciate any comment or possible scenario where this behaviour isn't expected.