### PR TITLE
fix: realtime interruption

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -847,7 +847,9 @@ class AgentActivity(RecognitionHooks):
 
         return interrupted_speeches
 
-    def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
+    def interrupt(
+        self, *, force: bool = False, omit_rt_interrupt: bool = False
+    ) -> asyncio.Future[None]:
         """Interrupt the current speech generation and any queued speeches.
 
         Returns:
@@ -868,9 +870,7 @@ class AgentActivity(RecognitionHooks):
             speech.interrupt(force=force)
             interrupted_speeches.append(speech)
 
-        if self._rt_session is not None and (
-            not self._rt_session.realtime_model.capabilities.turn_detection or force
-        ):
+        if self._rt_session is not None and not omit_rt_interrupt:
             self._rt_session.interrupt()
 
         if not interrupted_speeches:
@@ -1019,7 +1019,9 @@ class AgentActivity(RecognitionHooks):
         # self.interrupt() is going to raise when allow_interruptions is False, llm.InputSpeechStartedEvent is only fired by the server when the turn_detection is enabled.  # noqa: E501
         # When using the server-side turn_detection, we don't allow allow_interruptions to be False.
         try:
-            self.interrupt()  # input_speech_started is also interrupting on the serverside realtime session  # noqa: E501
+            self.interrupt(
+                omit_rt_interrupt=True
+            )  # input_speech_started is also interrupting on the serverside realtime session  # noqa: E501
         except RuntimeError:
             logger.exception(
                 "RealtimeAPI input_speech_started, but current speech is not interruptable, this should never happen!"  # noqa: E501

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -868,7 +868,9 @@ class AgentActivity(RecognitionHooks):
             speech.interrupt(force=force)
             interrupted_speeches.append(speech)
 
-        if self._rt_session is not None:
+        if self._rt_session is not None and (
+            not self._rt_session.realtime_model.capabilities.turn_detection or force
+        ):
             self._rt_session.interrupt()
 
         if not interrupted_speeches:

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -854,7 +854,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         return handle
 
-    def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
+    def interrupt(
+        self, *, force: bool = False, omit_rt_interrupt: bool = False
+    ) -> asyncio.Future[None]:
         """Interrupt the current speech generation.
 
         Returns:
@@ -864,7 +866,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         if self._activity is None:
             raise RuntimeError("AgentSession isn't running")
 
-        return self._activity.interrupt(force=force)
+        return self._activity.interrupt(force=force, omit_rt_interrupt=omit_rt_interrupt)
 
     def clear_user_turn(self) -> None:
         # clear the transcription or input audio buffer of the user turn


### PR DESCRIPTION
## Description

When we're using a Realtime Model with server side VAD, the server is responsible of generating `input_speech_started` events. In that cases, we don't want to send a `cancel` event to the model as we would be self interrupting ourselves.

Example of current flow:
- We receive an `input_speech_started` event ([see handle](https://github.com/livekit/agents/blob/06f5321bba0eb90863396df72eb4972d70ebf86a/livekit-agents/livekit/agents/voice/agent_activity.py#L1013-L1024))
- Since we use server interruption, we allow_interruptions can't be false
- Then in `interrupt` we would be sending an interruption to the server (from the server's own event)

Appreciate any comment or possible scenario where this behaviour isn't expected.