### PR TITLE
fix: oai rt interruption

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -931,7 +931,9 @@ class AgentActivity(RecognitionHooks):
 
         return interrupted_speeches
 
-    def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
+    def interrupt(
+        self, *, force: bool = False, omit_rt_interrupt: bool = False
+    ) -> asyncio.Future[None]:
         """Interrupt the current speech generation and any queued speeches.
 
         Returns:
@@ -952,9 +954,7 @@ class AgentActivity(RecognitionHooks):
             speech.interrupt(force=force)
             interrupted_speeches.append(speech)
 
-        if self._rt_session is not None and (
-            not self._rt_session.realtime_model.capabilities.turn_detection or force
-        ):
+        if self._rt_session is not None and not omit_rt_interrupt:
             self._rt_session.interrupt()
 
         if not interrupted_speeches:
@@ -1114,7 +1114,9 @@ class AgentActivity(RecognitionHooks):
         # self.interrupt() is going to raise when allow_interruptions is False, llm.InputSpeechStartedEvent is only fired by the server when the turn_detection is enabled.  # noqa: E501
         # When using the server-side turn_detection, we don't allow allow_interruptions to be False.
         try:
-            self.interrupt()  # input_speech_started is also interrupting on the serverside realtime session  # noqa: E501
+            self.interrupt(
+                omit_rt_interrupt=True
+            )  # input_speech_started is also interrupting on the serverside realtime session  # noqa: E501
         except RuntimeError:
             logger.exception(
                 "RealtimeAPI input_speech_started, but current speech is not interruptable, this should never happen!"  # noqa: E501

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1111,12 +1111,8 @@ class AgentActivity(RecognitionHooks):
         if self.vad is None:
             self._session._update_user_state("speaking")
 
-        # self.interrupt() is going to raise when allow_interruptions is False, llm.InputSpeechStartedEvent is only fired by the server when the turn_detection is enabled.  # noqa: E501
-        # When using the server-side turn_detection, we don't allow allow_interruptions to be False.
         try:
-            self.interrupt(
-                omit_rt_interrupt=True
-            )  # input_speech_started is also interrupting on the serverside realtime session  # noqa: E501
+            self.interrupt(omit_rt_interrupt=True)
         except RuntimeError:
             logger.exception(
                 "RealtimeAPI input_speech_started, but current speech is not interruptable, this should never happen!"  # noqa: E501

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -952,7 +952,9 @@ class AgentActivity(RecognitionHooks):
             speech.interrupt(force=force)
             interrupted_speeches.append(speech)
 
-        if self._rt_session is not None:
+        if self._rt_session is not None and (
+            not self._rt_session.realtime_model.capabilities.turn_detection or force
+        ):
             self._rt_session.interrupt()
 
         if not interrupted_speeches:

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -958,7 +958,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         return handle
 
-    def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
+    def interrupt(
+        self, *, force: bool = False, omit_rt_interrupt: bool = False
+    ) -> asyncio.Future[None]:
         """Interrupt the current speech generation.
 
         Returns:
@@ -968,7 +970,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         if self._activity is None:
             raise RuntimeError("AgentSession isn't running")
 
-        return self._activity.interrupt(force=force)
+        return self._activity.interrupt(force=force, omit_rt_interrupt=omit_rt_interrupt)
 
     def clear_user_turn(self) -> None:
         # clear the transcription or input audio buffer of the user turn

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -958,9 +958,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         return handle
 
-    def interrupt(
-        self, *, force: bool = False, omit_rt_interrupt: bool = False
-    ) -> asyncio.Future[None]:
+    def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
         """Interrupt the current speech generation.
 
         Returns:
@@ -970,7 +968,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         if self._activity is None:
             raise RuntimeError("AgentSession isn't running")
 
-        return self._activity.interrupt(force=force, omit_rt_interrupt=omit_rt_interrupt)
+        return self._activity.interrupt(force=force)
 
     def clear_user_turn(self) -> None:
         # clear the transcription or input audio buffer of the user turn


### PR DESCRIPTION
Prevent double interruption on OpenAI Realtime which causes weird behaviour with pre-connect buffer feature