### PR TITLE
fix: concatenate system instructions with generate_reply instructions

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -875,6 +875,9 @@ class AgentActivity(RecognitionHooks):
         )
 
         if isinstance(self.llm, llm.RealtimeModel):
+            # see: https://github.com/livekit/agents/issues/3834 for more details
+            if instructions:
+                instructions = "\n".join([self._agent.instructions, instructions])
             self._create_speech_task(
                 self._realtime_reply_task(
                     speech_handle=handle,


### PR DESCRIPTION
This follows the Pipeline behaviour and properly drives Realtime model for generating the response, otherwise, the system prompt instructions aren't properly followed (as if they were fully overriden for the interaction)